### PR TITLE
Adicionado o CNAME como parte do build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ __pycache__
 
 # pug-se.github.io
 pug-se.github.io
+
+# VSCode
+.vscode

--- a/baseconf.py
+++ b/baseconf.py
@@ -57,7 +57,7 @@ PLUGINS = [
         ]
 
 # Static content
-STATIC_PATHS = ['extra/CNAME']
+STATIC_PATHS = ['images', 'extra/CNAME']
 EXTRA_PATH_METADATA = {'extra/CNAME': {'path': 'CNAME'},}
 
 # Plugins settings

--- a/baseconf.py
+++ b/baseconf.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 SITEURL = ''
 DEFAULT_LANG = u'pt'
 DEFAULT_PAGINATION = False
-TIMEZONE = 'America/Sao_Paulo'
+TIMEZONE = 'America/Maceio'
 SUMMARY_MAX_LENGTH = 35
 
 ### URL and Page generation settings
@@ -55,6 +55,10 @@ PLUGINS = [
         'sitemap',
         'welcome-helpers',
         ]
+
+# Static content
+STATIC_PATHS = ['extra/CNAME']
+EXTRA_PATH_METADATA = {'extra/CNAME': {'path': 'CNAME'},}
 
 # Plugins settings
 RESPONSIVE_IMAGES = True

--- a/content/extra/CNAME
+++ b/content/extra/CNAME
@@ -1,0 +1,1 @@
+se.python.org.br


### PR DESCRIPTION
O arquivo CNAME (necessário para a publicação do site) foi adicionado como arquivo estático ao build. Dessa forma todo build gerado já incluirá o arquivo na raiz do site.